### PR TITLE
refactor types in SL+LPO constraint

### DIFF
--- a/CO4/Test/TermComp2014/Proof/Dump.hs
+++ b/CO4/Test/TermComp2014/Proof/Dump.hs
@@ -9,18 +9,18 @@ import CO4.Test.TermComp2014.Standalone
 import CO4.Test.TermComp2014.Util
 import CO4.Test.TermComp2014.Config
 
-dumpTrs :: Config -> SymbolMap -> DPTrs () -> IO ()
+dumpTrs :: Config -> SymbolMap -> UnlabeledTrs -> IO ()
 dumpTrs config symbolMap dp = do
   print $ "Configuration:" 
   print $ show config
 
-  print $ "DP-TRS:"
-  print $ pprintDPTrs (const "") symbolMap dp
+  print $ "Trs:"
+  print $ pprintUnlabeledTrs symbolMap dp
 
   print $ "Symbol Map:"
   print $ show symbolMap
 
-dump :: Config -> SymbolMap -> DPTrs () -> Proof -> IO ()
+dump :: Config -> SymbolMap -> UnlabeledTrs -> Proof -> IO ()
 dump config symbolMap dp (Proof model orders) = do
   print $ "\n#######################################\n"
 
@@ -28,7 +28,7 @@ dump config symbolMap dp (Proof model orders) = do
   print $ pprintModel pprintSymbolWithMark symbolMap model
 
   print $ "Labeled Trs:"
-  print $ pprintDPTrs pprintLabel symbolMap $ ungroupTrs labeledTrs
+  print $ pprintLabeledTrs pprintLabel symbolMap $ ungroupTrs labeledTrs
 
   forM_ (zip [1..] orders ) $ \ (i,(_,order)) -> do
    case order of
@@ -41,20 +41,20 @@ dump config symbolMap dp (Proof model orders) = do
       print $ pprintArgFilter pprintSymbolWithMark pprintLabel symbolMap filter
 
       print $ show i ++ ". Filtered Trs:"
-      print $ pprintDPTrs pprintLabel symbolMap 
-            $ filterArgumentsDPTrs filter 
+      print $ pprintLabeledTrs pprintLabel symbolMap 
+            $ filterArgumentsLabeledTrs filter 
             $ ungroupTrs labeledTrs
 
       print $ show i ++ ". Precedence:"
       print $ pprintPrecedence pprintSymbolWithMark pprintLabel symbolMap precedence
 
   print $ "\nDeleted:"
-  print $ unlines $ map (pprintDPRule (const "") symbolMap) delete
+  print $ unlines $ map (pprintUnlabeledRule symbolMap) delete
 
   -- FIXME: print information about intermediates
   forM_ ints $ \ int -> do
       print $ "\nIntermediate system:"
-      print $ pprintTaggedDPTrs pprintLabel symbolMap int
+      print $ pprintTaggedLabeledTrs pprintLabel symbolMap int
 
   where
    ints              = intermediates dp labeledTrs orders

--- a/CO4/Test/TermComp2014/Run.hs
+++ b/CO4/Test/TermComp2014/Run.hs
@@ -35,7 +35,7 @@ runN config trs =
                                  . T.DpTrans (T.DPS tpdbStrictRules) True )
   where
     tpdbDp          = T.dp trs
-    tpdbStrictRules = filter T.strict $ toTPDBRules symbolMap (const . T.fromMarkedIdentifier) dp
+    tpdbStrictRules = filter T.strict $ unlabeledTrsToTPDBRules symbolMap T.fromMarkedIdentifier dp
     (dp, symbolMap) = fromTPDBTrs tpdbDp
 
     goDP dp = case hasMarkedRule dp of
@@ -61,8 +61,8 @@ run1 config trs = do
       in
         return $ Just (trs', proof)
 
-run1' :: SymbolMap -> Config -> DPTrs () 
-      -> IO (Maybe (DPTrs (), [DPRule ()], T.DpProof -> T.DpProof ))
+run1' :: SymbolMap -> Config -> UnlabeledTrs
+      -> IO (Maybe (UnlabeledTrs, [UnlabeledRule], T.DpProof -> T.DpProof ))
 run1' symbolMap config dp = 
   let mValues   = modelValues $ modelBitWidth config
       parameter = (dp, mValues)


### PR DESCRIPTION
I've refactored the `Term` type

```
data Term var node = Var  var | Node node [Term var node]
```

so that labels are part of the nodes' signature:

```
type LabeledTerm label = Term Symbol (Symbol,label)
```
